### PR TITLE
tabletWide in theme changed

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -24,6 +24,6 @@ export const theme = {
     mobile: "900px",
     narrow: "950px",
     tabletMedium: "1050px",
-    tabletWide: "1280px",
+    tabletWide: "1200px",
   },
 };


### PR DESCRIPTION
tabletWide property changed from 1280px to 1200px because on MacBooks with the commonly encountered 13-inch screen size, 3 video windows appeared at startup instead of 4.